### PR TITLE
fix ScalarSearchOperator/VectorSearchOperator imports in diracx.py

### DIFF
--- a/dirac-mcp/src/dirac_mcp/diracx.py
+++ b/dirac-mcp/src/dirac_mcp/diracx.py
@@ -2,7 +2,8 @@ from typing import List, Dict, Optional, Any
 from mcp.server.fastmcp import FastMCP
 
 from diracx.client.aio import AsyncDiracClient
-from diracx.core.models import ScalarSearchOperator, VectorSearchOperator
+
+from diracx.core.models.search import ScalarSearchOperator, VectorSearchOperator  # type: ignore[no-redef]
 
 # Create an MCP server
 mcp = FastMCP("DiracX Services")


### PR DESCRIPTION
Update `dirac-mcp/src/dirac_mcp/diracx.py ` to fix  `ScalarSearchOperator,` `VectorSearchOperator ` imports to use `diracx.core.models.search`.

Closes #12 